### PR TITLE
Fix js url for keyboardteleop.html

### DIFF
--- a/examples/keyboardteleop.html
+++ b/examples/keyboardteleop.html
@@ -8,8 +8,8 @@
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/jquery-ui.min.js"></script>
-<script src="http://cdn.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js"></script>
-<script src="http://cdn.robotwebtools.org/roslibjs/current/roslib.js"></script>
+<script src="http://static.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js"></script>
+<script src="http://static.robotwebtools.org/roslibjs/current/roslib.js"></script>
 <script src="../build/keyboardteleop.js"></script>
 
 <script>


### PR DESCRIPTION
I fixed URL for javascript files.

The old URLs are not found.